### PR TITLE
Add map controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,8 +120,12 @@
             height: 50px !important;
         }
 
+        .mapboxgl-ctrl-bottom-right .mapboxgl-ctrl-group {
+            margin: 0 30px 30px 0 !important;
+        }
+
         .mapboxgl-ctrl-top-right .mapboxgl-ctrl {
-            margin: 20px 20px 0 0 !important;
+            margin: 30px 30px 0 0 !important;
         }
 
     </style>
@@ -173,6 +177,8 @@
     }),'bottom-right');
 
     map.addControl(new mapboxgl.NavigationControl());
+
+    map.resize();
 
     // Function to help build a query string for querying the ArcGIS REST service
     function queryString(queryProperties) {

--- a/index.html
+++ b/index.html
@@ -115,6 +115,11 @@
             height: 50px !important;
         }
 
+        .mapboxgl-ctrl-geolocate > button{
+            width: 50px !important;
+            height: 50px !important;
+        }
+
         .mapboxgl-ctrl-top-right .mapboxgl-ctrl {
             margin: 20px 20px 0 0 !important;
         }
@@ -122,8 +127,9 @@
     </style>
 
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css' rel='stylesheet' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.0/mapbox-gl.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.0/mapbox-gl.css' rel='stylesheet' />
+    
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -149,6 +149,8 @@
         zoom: 12
     });
 
+    map.addControl(new mapboxgl.NavigationControl());
+
     // Function to help build a query string for querying the ArcGIS REST service
     function queryString(queryProperties) {
         let queryString = '';

--- a/index.html
+++ b/index.html
@@ -159,6 +159,13 @@
         zoom: 12
     });
 
+    map.addControl(new mapboxgl.GeolocateControl({
+        positionOptions: {
+            enableHighAccuracy: true
+        },
+        trackUserLocation: true
+    }),'bottom-right');
+
     map.addControl(new mapboxgl.NavigationControl());
 
     // Function to help build a query string for querying the ArcGIS REST service

--- a/index.html
+++ b/index.html
@@ -178,8 +178,6 @@
 
     map.addControl(new mapboxgl.NavigationControl());
 
-    map.resize();
-
     // Function to help build a query string for querying the ArcGIS REST service
     function queryString(queryProperties) {
         let queryString = '';
@@ -423,6 +421,8 @@
                 'circle-radius': 4,
             }
         });
+
+        map.resize();
     })
 
 

--- a/index.html
+++ b/index.html
@@ -12,9 +12,10 @@
 
         #map {
             position: absolute;
-            top: 75px;
-            bottom: 80px;
+            /* top: 75px;
+            bottom: 80px; */
             width: 100%;
+            height: 100%
         }
 
         #header {

--- a/index.html
+++ b/index.html
@@ -12,10 +12,9 @@
 
         #map {
             position: absolute;
-            /* top: 75px;
-            bottom: 80px; */
+            top: 75px;
+            bottom: 80px;
             width: 100%;
-            height: 100%
         }
 
         #header {

--- a/index.html
+++ b/index.html
@@ -109,6 +109,16 @@
         #citrix {
             background: #f9423a;
         }
+
+        .mapboxgl-ctrl-group > button{
+            width: 50px !important;
+            height: 50px !important;
+        }
+
+        .mapboxgl-ctrl-top-right .mapboxgl-ctrl {
+            margin: 20px 20px 0 0 !important;
+        }
+
     </style>
 
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">


### PR DESCRIPTION
Add a compass, zoom in / out, and location dot.  I messed with the styling, but getting it looking right on both phones and desktops was difficult.  Obviously feel free to mess with it.

Check it out here: https://5df4594273bf560009fe8526--adoring-wing-48a930.netlify.com/

NOTE: I found an issue with the location dot being off when running it on my Note 9, but nowhere else. It is reported here: https://github.com/mapbox/mapbox-gl-js/issues/9111